### PR TITLE
mrc-2121 Alter vue dynamic form readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,10 @@ At the moment only 3 control types are supported:
 
 ## Testing, building and publishing
 * To run unit tests with jest: `npm test`
-* To build distribution files: `npm build`
+* To build distribution files: `npm run-script build`
 * To publish to npm: 
     * first iterate the version in `package.json`
+    * create a user account if you don't have one
+    * request organization membership to join 'reside-ic'
+    * log into your account : 'npm login'
     * then `npm publish --access public`

--- a/README.md
+++ b/README.md
@@ -226,6 +226,6 @@ At the moment only 3 control types are supported:
 * To publish to npm: 
     * first iterate the version in `package.json`
     * create a user account if you don't have one
-    * request organization membership to join 'reside-ic'
-    * log into your account : 'npm login'
+    * request organization membership to join `reside-ic`
+    * log into your account : `npm login`
     * then `npm publish --access public`


### PR DESCRIPTION
This PR adds that user needs to be logged into npm in order to publish + have permissions.
change 'npm build' to 'npm run-script build'